### PR TITLE
Set function name as Symbol Description

### DIFF
--- a/metho.js
+++ b/metho.js
@@ -1,38 +1,35 @@
-export function add(target, f, outerSyntax=false){
-  return f.length ?
-    outerSyntax ?
-      addProperty(target, f)
-    :
-      addWithParams(target, f)
-  :
-    addSimple(target, f)
+export function add(target, f, outerSyntax = false) {
+  return f.length
+    ? outerSyntax
+      ? addProperty(target, f)
+      : addWithParams(target, f)
+    : addSimple(target, f);
 }
 
 export function addProperty(target, f) {
-  const s = Symbol()
-  target[s] = f
-  return s
+  const s = Symbol(f.name);
+  target[s] = f;
+  return s;
 }
 
 export function addWithParams(target, f) {
-  return(function(...args) {
-    const s = Symbol()
+  return function (...args) {
+    const s = Symbol(f.name);
     Object.defineProperty(target, s, {
       configurable: true,
-      get: function() {
-        delete target[s]
-        return f.apply(this, args)
-      }
-    })
-    return s
-  })
+      get: function () {
+        delete target[s];
+        return f.apply(this, args);
+      },
+    });
+    return s;
+  };
 }
 
 export function addSimple(target, f) {
-  const s = Symbol()
-  Object.defineProperty(target, s, { configurable:true, get: f})
-  return s
+  const s = Symbol(f.name);
+  Object.defineProperty(target, s, { configurable: true, get: f });
+  return s;
 }
-
 
 // may well need the ability to add descriptions for these Symbols that are flying around


### PR DESCRIPTION
You leave a message at the end of the code talking about adding a description to the Symbols. What about using the function's name as a description?

This PR also includes some syntax fixes to make the close easier to read.