### PR TITLE
Adds better handling for methods with optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ There is a slight performance hit when not using `outerSyntax` - hence the reaso
 **Important note** - it has been pointed out that functions with a default argument(s) that start from the first argument do not seem to work correctly with the `add` method. Whilst they do *seem* to behave oddly, they are actually behaving correctly as they do not actually *expect* any arguments (for a clearer explanation, see the information about [`function.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) on MDN). If you want to add such methods you should use the `addWithParams` method directly.
 
 ### `addWithParams(targetOrTargets, function, [options={}])`
-Adds a 'dynamic property` that can accept parameters
+Adds a 'dynamic property` that can accept parameters. If you wish to pass **no** parameters when calling it, you can simply omit the parentheses - this is particularly useful in the case of functions where all parameters have defaults or are entirely optional.
 ```js
-console.log(object[property(param1, param2)]
+console.log(object[property(param1, param2)]  // call the dynamic property and pass parameters
+console.log(object[propertyWithDefaultParams])  // equivalent to object[propertyWithDefaultParams()]
+
 ```
 
 ### `addSimple(targetOrTargets, function, [options={}])`

--- a/index.html
+++ b/index.html
@@ -10,6 +10,16 @@
 	<script type="module">
 		import * as Metho from "./metho.js"
 
+		const first = Metho.addWithParams(
+			String.prototype,
+			function first(count=1) {
+				return this.slice(0, count)
+			}
+		)
+
+		console.log("World"[first])
+		console.log("World"[first(3)])
+
 		// const hexxy = Symbol('hexxy')
 
 		// const hex = Metho.add(Number.prototype, function hex() { return this.toString(16) }, {useSymbol: hexxy})

--- a/metho.js
+++ b/metho.js
@@ -55,6 +55,7 @@ export function addWithParams(
 		},
 	}
 	buildTempMethod[methodName].targets = sanitiseTargets(targetOrTargets)
+	buildTempMethod[methodName].toString = ()=>buildTempMethod[methodName]()
 	register && addToRegister(symbolName, buildTempMethod[methodName])
 	return buildTempMethod[methodName]
 }


### PR DESCRIPTION
Methods with optional parameters can now be called without parameters by simply omitting the parentheses